### PR TITLE
User addEventListener event only when is available on client-side

### DIFF
--- a/mixpanel-patched.js
+++ b/mixpanel-patched.js
@@ -3767,14 +3767,16 @@ var add_dom_loaded_handler = function() {
         });
     }
 
-    if (document$1.readyState === 'complete') {
-        // safari 4 can fire the DOMContentLoaded event before loading all
-        // external JS (including this file). you will see some copypasta
-        // on the internet that checks for 'complete' and 'loaded', but
-        // 'loaded' is an IE thing
-        dom_loaded_handler();
-    } else {
-        document$1.addEventListener('DOMContentLoaded', dom_loaded_handler, false);
+    if (document$1.addEventListener) {
+      if (document$1.readyState === 'complete') {
+          // safari 4 can fire the DOMContentLoaded event before loading all
+          // external JS (including this file). you will see some copypasta
+          // on the internet that checks for 'complete' and 'loaded', but
+          // 'loaded' is an IE thing
+          dom_loaded_handler();
+      } else {
+          document$1.addEventListener('DOMContentLoaded', dom_loaded_handler, false);
+      }
     }
 };
 


### PR DESCRIPTION
closes https://github.com/okotoki/mixpanel-figma/issues/6

Without this patch I can not run my Nextjs problem
<img width="1000" alt="Screenshot 2023-09-20 at 13 45 19" src="https://github.com/okotoki/mixpanel-figma/assets/22928302/b9bc2dd6-8a8f-4c77-a1e1-522f5059409d">


